### PR TITLE
Add dark mode to articles

### DIFF
--- a/_includes/article-head.html
+++ b/_includes/article-head.html
@@ -1,6 +1,7 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="color-scheme" content="light dark" />
   <meta name="description" content="{{ page.description }}" />
   <title>Not a Hat &mdash; {{ page.title }}</title>
 

--- a/_sass/articles.scss
+++ b/_sass/articles.scss
@@ -3,6 +3,26 @@
 
 $page-width: 576px;
 
+:root {
+  --color-bg: white;
+  --color-text: black;
+  --color-link-decoration: #999;
+  --color-link-hover: #4588bb;
+  --color-code-bg: #f6f6f6;
+  --color-border: #ccc;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --color-bg: #1a1a1a;
+    --color-text: #e0e0e0;
+    --color-link-decoration: #666;
+    --color-link-hover: #6aabdc;
+    --color-code-bg: #2a2a2a;
+    --color-border: #555;
+  }
+}
+
 // Below this size, we shrink the page margins.
 // 450px is a little bigger than the iPhone 13 Pro width of 428px.
 $page-margin-breakpoint: 450px;
@@ -22,8 +42,8 @@ $page-margin-breakpoint: 450px;
 }
 
 html {
-  background-color: white;
-  color: black;
+  background-color: var(--color-bg);
+  color: var(--color-text);
   @include serif-font;
 }
 
@@ -37,10 +57,10 @@ body {
 
 a {
   color: inherit;
-  text-decoration-color: #999;
+  text-decoration-color: var(--color-link-decoration);
 
   &:hover {
-    color: #4588bb;
+    color: var(--color-link-hover);
     text-decoration-color: currentcolor;
   }
 }
@@ -179,7 +199,7 @@ a {
     margin: 1rem -1rem;
     padding: 0.3rem 1rem 0.5rem;
     overflow-x: auto;
-    background-color: #f6f6f6;
+    background-color: var(--color-code-bg);
 
     @media (min-width: $page-margin-breakpoint) {
       margin: 1rem -2rem;
@@ -202,7 +222,7 @@ a {
   blockquote {
     margin: 0;
     padding-left: 1rem;
-    border-left: 2px solid #ccc;
+    border-left: 2px solid var(--color-border);
   }
 
   hr {
@@ -212,7 +232,7 @@ a {
 
     &::after {
       content: "✦";
-      color: #ccc;
+      color: var(--color-border);
     }
   }
 

--- a/_sass/highlight.scss
+++ b/_sass/highlight.scss
@@ -1,9 +1,11 @@
-// Generated from pygments with:
+// Light mode colors generated from pygments with:
 //
 //   pygmentize -f html -S xcode
 //
 // See https://pygments.org/styles/ for possible styles.
 // Note that only a few of them are WCAG compliant.
+//
+// Dark mode colors are hand-tuned lightened equivalents of the xcode palette.
 
 .highlight {
   /* Comment */
@@ -309,5 +311,59 @@
   /* Literal.Number.Integer.Long */
   .il {
     color: #1c01ce;
+  }
+}
+
+@media (prefers-color-scheme: dark) {
+  .highlight {
+    /* Comment */
+    .c, .ch, .cm, .cpf, .c1, .cs {
+      color: #6aab5f;
+    }
+
+    /* Comment.Preproc */
+    .cp {
+      color: #ce9178;
+    }
+
+    /* Error, Name.* (default text) */
+    .err, .n, .o, .no, .nd, .ni, .ne, .nf, .nl, .nn, .nx, .py, .nt, .nv, .ow, .fm, .vc, .vg, .vi, .vm {
+      color: #e0e0e0;
+    }
+
+    /* Keyword.* */
+    .k, .kc, .kd, .kn, .kp, .kr, .kt, .nb {
+      color: #da8fda;
+    }
+
+    /* Literal, Literal.Number.* */
+    .l, .ld, .m, .mb, .mf, .mh, .mi, .mo, .il {
+      color: #7c9fff;
+    }
+
+    /* Literal.String.* */
+    .s, .sa, .sb, .dl, .sd, .s2, .se, .sh, .si, .sx, .sr, .s1, .ss {
+      color: #e08080;
+    }
+
+    /* Literal.String.Char */
+    .sc {
+      color: #9ba8ff;
+    }
+
+    /* Name.Attribute */
+    .na {
+      color: #c8a84b;
+    }
+
+    /* Name.Class */
+    .nc {
+      color: #4ec9b0;
+    }
+
+    /* Name.Builtin.Pseudo */
+    .bp {
+      color: #c678dd;
+    }
   }
 }


### PR DESCRIPTION
## Summary

- Introduces CSS custom properties for all colours in `articles.scss`, with a `prefers-color-scheme: dark` override block
- Adds `<meta name="color-scheme" content="light dark">` so the browser applies native dark defaults before CSS loads
- Adds dark mode colour overrides for Pygments syntax highlighting in `highlight.scss` (hand-tuned from the xcode palette)

## Test plan

- [ ] Run `bundle exec jekyll serve` and open an article
- [ ] Use Chrome DevTools → Rendering → "Emulate CSS media feature prefers-color-scheme" to toggle dark/light
- [ ] Check body, links, code blocks, blockquotes, and syntax highlighting look correct in both modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)